### PR TITLE
Fix error when calling `/audio_query`

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -41,14 +41,14 @@ export class RestAPI {
 
   async createAudioQuery(
     text: string,
-    speaker_id: number,
+    speaker: number,
     options: {
       core_version?: string;
     }
   ): Promise<audioQuery> {
     let params: createAudioQueryOptions = {
       text: text,
-      speaker_id: speaker_id,
+      speaker: speaker,
     };
     if (options.core_version) {
       params["core_version"] = options.core_version;

--- a/src/types/audioquery.ts
+++ b/src/types/audioquery.ts
@@ -29,6 +29,6 @@ interface mora {
 
 export interface createAudioQueryOptions {
   text: string;
-  speaker_id: number;
+  speaker: number;
   core_version?: string;
 }


### PR DESCRIPTION
This is the voicevox error log.

```
INFO:     127.0.0.1:51073 - "POST /audio_query?text=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF&speaker_id=0 HTTP/1.1" 422 Unprocessable Entity
```

It seems that `speaker` is correct instead of `speaker_id`.

Version information:

```
/version
"0.14.5"
/core_versions
[
  "0.14.4"
]
```
