### PR TITLE
Fix error when calling `/synthesis`

### DIFF
--- a/src/rest.ts
+++ b/src/rest.ts
@@ -3,6 +3,7 @@ import { synthesisParams } from "./types/synthesis";
 
 type fetchOptions = {
   method: string;
+  headers?: Record<string, string>;
   body?: any;
 };
 
@@ -29,6 +30,7 @@ export class RestAPI {
       method: method,
     };
     if (options.body) {
+      fetch_options["headers"] = { "Content-Type": "application/json" };
       fetch_options["body"] = JSON.stringify(options.body);
     }
     let response = await fetch(url, fetch_options);


### PR DESCRIPTION
This is the voicevox error log.

```
INFO:     127.0.0.1:51496 - "POST /synthesis?speaker=0 HTTP/1.1" 422 Unprocessable Entity
```

`Content-Type` needed to be set.
