### PR TITLE
Add createAudioQueryFromPreset

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -44,4 +44,27 @@ export class Client {
     let audioquery = await this.rest.createAudioQuery(text, speaker, options);
     return new audioQuery(this.rest, audioquery);
   }
+
+  // Create audio query from preset
+  /**
+   * @param text - Japanese text
+   * @param preset_id - Preset ID
+   * @param options - Options
+   * @param options.core_version - Core version
+   */
+  async createAudioQueryFromPreset(
+    text: string,
+    preset_id: number,
+    options?: {
+      core_version?: string;
+    }
+  ): Promise<audioQuery> {
+    options ??= {};
+    let audioquery = await this.rest.createAudioQueryFromPreset(
+      text,
+      preset_id,
+      options
+    );
+    return new audioQuery(this.rest, audioquery);
+  }
 }

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,4 +1,8 @@
-import { audioQuery, createAudioQueryOptions } from "./types/audioquery";
+import {
+  audioQuery,
+  createAudioQueryOptions,
+  createAudioQueryFromPresetOptions,
+} from "./types/audioquery";
 import { synthesisParams } from "./types/synthesis";
 
 type fetchOptions = {
@@ -56,6 +60,25 @@ export class RestAPI {
       params["core_version"] = options.core_version;
     }
     return await this.request("POST", "/audio_query", {
+      params: params,
+    });
+  }
+
+  async createAudioQueryFromPreset(
+    text: string,
+    preset_id: number,
+    options: {
+      core_version?: string;
+    }
+  ): Promise<audioQuery> {
+    let params: createAudioQueryFromPresetOptions = {
+      text: text,
+      preset_id: preset_id,
+    };
+    if (options.core_version) {
+      params["core_version"] = options.core_version;
+    }
+    return await this.request("POST", "/audio_query_from_preset", {
       params: params,
     });
   }

--- a/src/types/audioquery.ts
+++ b/src/types/audioquery.ts
@@ -32,3 +32,9 @@ export interface createAudioQueryOptions {
   speaker: number;
   core_version?: string;
 }
+
+export interface createAudioQueryFromPresetOptions {
+  text: string;
+  preset_id: number;
+  core_version?: string;
+}


### PR DESCRIPTION
Added `createAudioQueryFromPreset` method.

There are no test code, Because it depends on the voicevox engine state. However I tested it by running locally.
